### PR TITLE
fix memory leak

### DIFF
--- a/coolplayer/CLV_ListView.c
+++ b/coolplayer/CLV_ListView.c
@@ -287,6 +287,13 @@ void CLV_CleanupWindowData(CIs_ListViewData* pListData)
 			if (pListData->m_pColumns[iColumnIDX].m_pColumnText)
 				free(pListData->m_pColumns[iColumnIDX].m_pColumnText);
 		}
+		
+		free(pListData->m_pColumns);
+	}
+
+	if(pListData->m_piColumnOrder)
+	{
+		free(pListData->m_piColumnOrder);
 	}
 	
 	free(pListData);

--- a/coolplayer/CLV_ListView.c
+++ b/coolplayer/CLV_ListView.c
@@ -291,11 +291,11 @@ void CLV_CleanupWindowData(CIs_ListViewData* pListData)
 		free(pListData->m_pColumns);
 	}
 
-	if(pListData->m_piColumnOrder)
+	if (pListData->m_piColumnOrder)
 	{
 		free(pListData->m_piColumnOrder);
 	}
-	
+
 	free(pListData);
 }
 

--- a/coolplayer/CPSK_Skin.c
+++ b/coolplayer/CPSK_Skin.c
@@ -84,6 +84,7 @@ void CPSK_DestroySkin(CPs_Skin* pSkin)
 	CPIG_DestroyImage_WithState(pSkin->mpl_pVScrollBar_Up);
 	CPIG_DestroyImage_WithState(pSkin->mpl_pVScrollBar_Down);
 	CPIG_DestroyImage(pSkin->mpl_pSelection);
+	CPIG_DestroyImage(pSkin->mpl_pFocus);
 	
 	// Remove the command targets
 	{


### PR DESCRIPTION
1. in func CLV_CleanupWindowData should cleanup pListData->m_pColumns & pListData->m_piColumnOrder 2. in func CPSK_DestroySkin should cleanup pSkin->mpl_pFocus